### PR TITLE
update refs for main default branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           workspace: default
       - uses: ./
         name: Release
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           operation: release
           version: '0.0.1-beta1'

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ steps:
       workspace: default
   - uses: ./.github/actions/action-waypoint
     name: Release
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     with:
       operation: release
       version: '0.0.1-beta1'

--- a/__tests__/event.json
+++ b/__tests__/event.json
@@ -104,7 +104,7 @@
     "watchers": 0,
     "default_branch": "main",
     "stargazers": 0,
-    "main_branch": "main",
+    "master_branch": "main",
     "organization": "hashicorp"
   },
   "pusher": {

--- a/__tests__/event.json
+++ b/__tests__/event.json
@@ -1,5 +1,5 @@
 {
-  "ref": "refs/heads/master",
+  "ref": "refs/heads/main",
   "before": "1d42aab6ef030d484135ec6bcbf0b976079ab785",
   "after": "265283d6a318ff52e707dd80398ac80fd8343ac3",
   "repository": {
@@ -102,9 +102,9 @@
     "forks": 0,
     "open_issues": 0,
     "watchers": 0,
-    "default_branch": "master",
+    "default_branch": "main",
     "stargazers": 0,
-    "master_branch": "master",
+    "main_branch": "main",
     "organization": "hashicorp"
   },
   "pusher": {


### PR DESCRIPTION
@pearkes I couldn't find a reference to a `master_branch` key in the GitHub API docs for Actions, so I went ahead and updated that key here to reflect our new reference pattern. Let me know if there is a ref somewhere that expects one key or the other.