### PR TITLE
Switch to docker mirror

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: ./
         name: Setup
         with:
-          version: '0.0.1-beta1'
+          version: '0.1.4'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           waypoint_server_address: '2.tcp.ngrok.io:17860'
           waypoint_server_ui: 'https://localhost:9702'
@@ -22,18 +22,18 @@ jobs:
         name: Build
         with:
           operation: build
-          version: '0.0.1-beta1'
+          version: '0.1.4'
           workspace: default
       - uses: ./
         name: Deploy
         with:
           operation: deploy
-          version: '0.0.1-beta1'
+          version: '0.1.4'
           workspace: default
       - uses: ./
         name: Release
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           operation: release
-          version: '0.0.1-beta1'
+          version: '0.1.4'
           workspace: default

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 # This is for the test action
-FROM nginx
+FROM docker.mirror.hashicorp.services/nginx
 COPY test-html /usr/share/nginx/html


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're pointing to our mirror at docker.mirror.hashicorp.services. 

Also updated the tests version of waypoint, but see that secrets aren't passed to PR's :) 